### PR TITLE
feat: support WOFF2 to SVG

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[*.md]
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /Cargo.lock
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
-[patch.crates-io]
-skrifa  = { git="https://github.com/googlefonts/fontations.git", branch="main" }
-
 [package]
 name = "read-fonts-wasm"
 version = "0.1.0"
@@ -15,3 +12,8 @@ crate-type = ["cdylib"]
 skrifa = "0.1.0"
 wasm-bindgen = "0.2"
 js-sys = "0.3.61"
+woff2 = "0.3.0"
+
+[patch.crates-io]
+skrifa = { git="https://github.com/googlefonts/fontations.git", branch="main" }
+woff2 = { git="https://github.com/yisibl/woff2-rs", branch="fix-total-compressed-size" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,10 @@ use js_sys::{ArrayBuffer, Uint8Array};
 use skrifa::{
     raw::{FontRef, TableProvider},
     scale::{Context, Pen},
-    GlyphId, Size,
+    Size,
 };
 use wasm_bindgen::prelude::*;
+use woff2::decode::{convert_woff2_to_ttf, is_woff2};
 
 #[derive(Default)]
 struct SvgPen {
@@ -105,7 +106,13 @@ impl Pen for SvgPen {
 #[wasm_bindgen]
 pub fn svg_of_glyph_for_codepoint(cp: u32, buf: &ArrayBuffer) -> String {
     let rust_buf = Uint8Array::new(&buf).to_vec();
-    let font = match FontRef::new(&rust_buf) {
+    let ttf_buffer = if is_woff2(&rust_buf) {
+        convert_woff2_to_ttf(&mut std::io::Cursor::new(rust_buf)).unwrap()
+    } else {
+        rust_buf
+    };
+
+    let font = match FontRef::new(&ttf_buffer) {
         Ok(font) => font,
         Err(e) => return format!("FontRef::new failed: {e}"),
     };

--- a/test.html
+++ b/test.html
@@ -2,26 +2,74 @@
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
-    <title>hello-wasm example</title>
+    <title>read-fonts-wasm example</title>
     <style>
-        svg { width: 45%; }
+      main {
+        max-width: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+      }
+      .svg-list {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+      }
+      svg {
+        max-width: 100px;
+      }
     </style>
   </head>
   <body>
     <script type="module">
-      // Don't have woff2_decompress in Rust at time of writing and as far as I can tell the browser
-      // doesn't expose it to js
-      let font_url = "https://fonts.gstatic.com/s/materialicons/v140/flUhRq6tzZclQEJ-Vdg-IuiaDsNZ.ttf";
-      import init, { svg_of_glyph_for_codepoint } from "./pkg/read_fonts_wasm.js";      
+      let ttf_url = "https://fonts.gstatic.com/s/materialicons/v140/flUhRq6tzZclQEJ-Vdg-IuiaDsNZ.ttf";
+      let woff2_url = "https://fonts.gstatic.com/s/materialicons/v140/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2";
+
+      // See https://fonts.google.com/icons
+      // codepoints from https://github.com/google/material-design-icons/blob/master/font/MaterialIcons-Regular.codepoints
+      let icon_codepoints = [
+        'e8b8', // settings
+        'e87d', // favorite
+        'ea0b', // bolt
+        'ea99', // forest
+        'e1a3', // battery_charging_full
+      ]
+
+      function appendSvg(buffer, appendTo) {
+        for (const codepoint of icon_codepoints) {
+          let svg_string = svg_of_glyph_for_codepoint('0x' + codepoint, buffer);
+          const svg_node = document.createRange().createContextualFragment(svg_string);
+          document.querySelector(appendTo).appendChild(svg_node);
+        }
+      }
+
+      import init, { svg_of_glyph_for_codepoint } from './pkg/read_fonts_wasm.js';
+      await init(); // Init Wasm
+
       // Everyone returns promises so we end up with a lot of then's
-      init().then(() => fetch(font_url))      
+      fetch(ttf_url)
         .then((response) => response.arrayBuffer())
-        .then((buf) => {
-            // codepoints from https://github.com/google/material-design-icons/blob/master/font/MaterialIcons-Regular.codepoints
-            let svg_string = svg_of_glyph_for_codepoint(0xe855, buf);
-            const svgNode = document.createRange().createContextualFragment(svg_string);
-            document.body.appendChild(svgNode);
+        .then((buffer) => {
+          appendSvg(buffer, '.ttf');
+        });
+
+      fetch(woff2_url)
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => {
+          appendSvg(buffer, '.woff2');
         });
     </script>
+    <main>
+      <h1><a href="https://github.com/rsheeter/read-fonts-wasm" target="_b
+        ">read-fonts-wasm</a> example</h1>
+      <section>
+        <h2>TTF to SVG</h2>
+        <div class="svg-list ttf"></div>
+      </section>
+      <section>
+        <h2>WOFF2 to SVG</h2>
+        <div class="svg-list woff2"></div>
+      </section>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
- Use `woff2-rs` to decompress woff2 fonts.
- Add a comparison between TTF and WOFF2 after converting to SVG on the test page.

![image](https://user-images.githubusercontent.com/2784308/227196118-95f56758-86f5-456f-a7da-9276e805fe98.png)
